### PR TITLE
Fix typo in documentation for .product()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ macro_rules! impl_tuple_map {
             where
                  Self::Item: ::std::ops::AddAssign;
 
-            /// Takes `(a, b, c, ...)` then returns `a + b + c ...`
+            /// Takes `(a, b, c, ...)` then returns `a * b * c ...`
             fn product(self) -> Self::Item
             where
                  Self::Item: ::std::ops::MulAssign;


### PR DESCRIPTION
The description for the `.product()` method used the `+` addition operator, seemingly a copy-paste error from the `.sum()` method.
This commit replaces the `+` with the correct `*` multiplication operator.